### PR TITLE
allow a delay of 0 seconds in mobile environments

### DIFF
--- a/src/mediator.js
+++ b/src/mediator.js
@@ -262,7 +262,7 @@ const handleDragStartConditions = (function handleDragStartConditions() {
 
   return function(_startEvent, _delay, _clb) {
     startEvent = getPointerEvent(_startEvent);
-    delay = _delay || (isMobile ? 200 : 0);
+    delay = (typeof _delay === 'number') ? _delay : (isMobile ? 200 : 0);
     clb = _clb;
 
     registerEvents();


### PR DESCRIPTION
With the following line:

```js
delay = _delay || (isMobile ? 200 : 0)
```

a delay of `0` seconds is impossible on mobile devices.