### PR TITLE
allow dropping of copied content, part 1

### DIFF
--- a/src/dropHandlers.js
+++ b/src/dropHandlers.js
@@ -18,7 +18,13 @@ export function domDropHandler({ element, draggables, layout, options }) {
 		if (addedIndex !== null) {
 			const wrapper = global.document.createElement('div');
 			wrapper.className = `${wrapperClass}`;
-			wrapper.appendChild(removedWrapper.firstElementChild || droppedElement);
+			wrapper.appendChild(
+				removedWrapper && removedWrapper.firstElementChild ?
+				removedWrapper.firstElementChild :
+				options.behaviour === 'move' ?
+				droppedElement :
+				droppedElement.cloneNode(true)
+			);
 			wrapper[containersInDraggable] = [];
 			addChildAt(element, wrapper, addedIndex);
 			if (addedIndex >= draggables.length) {


### PR DESCRIPTION
Not sure how this is supposed to work, but without this change I can drag an item from one container to a second container with this second container having behaviour: 'copy'. If I don't add this, it is simply being removed from the first container.