### PR TITLE
remove global.Node `matches` polyfill

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -13,7 +13,7 @@
         return i > -1;
       };
   }
-})(global.Node || global.Element);
+})(global.Element);
 
 // Overwrites native 'firstElementChild' prototype.
 // Adds Document & DocumentFragment support for IE9 & Safari.


### PR DESCRIPTION
`matches` is not a method on a `Node` only on an `Element`