### PR TITLE
Fix type of `animationDuration`

### DIFF
--- a/src/exportTypes.ts
+++ b/src/exportTypes.ts
@@ -23,7 +23,7 @@ export interface DropResult {
 
 export interface DropPreviewOptions {
 	className?: string;
-	animationDuration?: string;
+	animationDuration?: number;
 	showOnTop?: boolean;
 }
 


### PR DESCRIPTION
Fixes #46, changing the type of `DropPreviewOptions.animationDuration` from `string` to `number`.