### PR TITLE
add option to disable scroll overlap detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ var container = SmoothDnD(containerElement, options);
 |dragBeginDelay|number| `0` (`200` for touch devices)|Time in milisecond. Delay to start dragging after item is pressed. Moving cursor before the delay more than 5px will cancel dragging.
 |animationDuration|number|`250`|Animation duration in milisecond. To be consistent this animation duration will be applied to both drop and reorder animations.|
 |autoScrollEnabled|boolean|`true`|First scrollable parent will scroll automatically if dragging item is close to boundaries.
+|disableScrollOverlapDetection|boolean|`false`|Will detect what elements overlap and only scroll on the direct element you're dragging over. Disabling this will scroll on all scrollable elements at the same time.
 |dragClass|string|`undefined`|Class to be added to the ghost item being dragged. The class will be added after it's added to the DOM so any transition in the class will be applied as intended.
 |dropClass|string|`undefined`|Class to be added to the ghost item just before the drop animation begins.|
 |removeOnDropOut|boolean|`undefined`|When set true onDrop will be called with a removedIndex if you drop element out of any relevant container|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smooth-dnd",
-  "version": "0.13.0",
+  "version": "0.12.1",
   "description": "Drag and Drop library",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "smooth-dnd",
+  "name": "@richardrout/smooth-dnd",
   "version": "0.12.0",
   "description": "Drag and Drop library",
   "main": "./dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@richardrout/smooth-dnd",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Drag and Drop library",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -7,6 +7,7 @@ export const defaultOptions: ContainerOptions = {
 	getChildPayload: undefined,
 	animationDuration: 250,
 	autoScrollEnabled: true,
+	disableScrollOverlapDetection: false,
 	shouldAcceptDrop: undefined,
 	shouldAnimateDrop: undefined,
 };

--- a/src/exportTypes.ts
+++ b/src/exportTypes.ts
@@ -7,6 +7,7 @@ export type SmoothDnDCreator = ((element: HTMLElement, options?: ContainerOption
 	dropHandler?: any;
 	wrapChild?: boolean;
 	maxScrollSpeed?: number;
+	disableScrollOverlapDetection?: boolean;
 	useTransformForGhost?: boolean;
 	cancelDrag: () => void;
 	isDragging: () => boolean;
@@ -45,6 +46,7 @@ export interface ContainerOptions {
 	dragBeginDelay?: number;
 	animationDuration?: number;
 	autoScrollEnabled?: boolean;
+	disableScrollOverlapDetection?: boolean;
 	lockAxis?: 'x' | 'y';
 	dragClass?: string;
 	dropClass?: string;

--- a/src/mediator.ts
+++ b/src/mediator.ts
@@ -576,7 +576,6 @@ function initiateDrag(position: MousePosition, cursor: string) {
       draggableInfo.container,
       cursor
     );
-    console.log(ghostInfo.centerDelta.x);
     draggableInfo.position = {
       x: position.clientX + ghostInfo.centerDelta.x,
       y: position.clientY + ghostInfo.centerDelta.y,

--- a/src/mediator.ts
+++ b/src/mediator.ts
@@ -540,7 +540,7 @@ function dragHandler(dragListeningContainers: IContainer[]): (draggableInfo: Dra
 
 function getScrollHandler(container: IContainer, dragListeningContainers: IContainer[]) {
   if (container.getOptions().autoScrollEnabled) {
-    return dragScroller(dragListeningContainers, container.getScrollMaxSpeed());
+    return dragScroller(dragListeningContainers, container.getScrollMaxSpeed(), container.getOptions().disableScrollOverlapDetection);
   } else {
     return (props: { draggableInfo?: DraggableInfo; reset?: boolean }) => null;
   }

--- a/src/mediator.ts
+++ b/src/mediator.ts
@@ -78,13 +78,10 @@ function getGhostParent() {
 }
 
 function getGhostElement(wrapperElement: HTMLElement, { x, y }: Position, container: IContainer, cursor: string): GhostInfo {
-  const wrapperRect = wrapperElement.getBoundingClientRect();
-  const { left, top, right, bottom } = wrapperRect;
-
-  const wrapperVisibleRect = Utils.getIntersection(container.layout.getContainerRectangles().visibleRect, wrapperRect);
-
-  const midX = wrapperVisibleRect.left + (wrapperVisibleRect.right - wrapperVisibleRect.left) / 2;
-  const midY = wrapperVisibleRect.top + (wrapperVisibleRect.bottom - wrapperVisibleRect.top) / 2;
+  const { left, top, right, bottom } = wrapperElement.getBoundingClientRect();
+  const midX = left + (right - left) / 2;
+  const midY = top + (bottom - top) / 2;
+    
   const ghost: HTMLElement = wrapperElement.cloneNode(true) as HTMLElement;
   ghost.style.zIndex = '1000';
   ghost.style.boxSizing = 'border-box';
@@ -578,6 +575,7 @@ function initiateDrag(position: MousePosition, cursor: string) {
       draggableInfo.container,
       cursor
     );
+    console.log(ghostInfo.centerDelta.x);
     draggableInfo.position = {
       x: position.clientX + ghostInfo.centerDelta.x,
       y: position.clientY + ghostInfo.centerDelta.y,

--- a/src/scroller.ts
+++ b/src/scroller.ts
@@ -214,7 +214,7 @@ function getTopmostScrollAnimator(animatorInfos: ScrollerAnimator[], position: P
 	return null;
 }
 
-export default (containers: IContainer[], maxScrollSpeed = maxSpeed) => {
+export default (containers: IContainer[], maxScrollSpeed = maxSpeed, disableOverlapDetection = false) => {
 	const animatorInfos = containers.reduce((acc: ScrollerAnimator[], container: IContainer) => {
 		const filteredAnimators = getScrollerAnimator(container).filter(p => {
 			return !acc.find(q => q.scrollerElement === p.scrollerElement);
@@ -256,18 +256,20 @@ export default (containers: IContainer[], maxScrollSpeed = maxSpeed) => {
 				}
 			});
 
-			const overlappingAnimators = animatorInfos.filter(p => p.cachedRect);
-			if (overlappingAnimators.length && overlappingAnimators.length > 1) {
-				// stop animations except topmost
-				const topScrollerAnimator = getTopmostScrollAnimator(overlappingAnimators, draggableInfo.mousePosition);
+			if (disableOverlapDetection !== true) {
+				const overlappingAnimators = animatorInfos.filter(p => p.cachedRect);
+				if (overlappingAnimators.length && overlappingAnimators.length > 1) {
+					// stop animations except topmost
+					const topScrollerAnimator = getTopmostScrollAnimator(overlappingAnimators, draggableInfo.mousePosition);
 
-				if (topScrollerAnimator) {
-					overlappingAnimators.forEach(p => {
-						if (p !== topScrollerAnimator) {
-							p.axisAnimations.x && p.axisAnimations.x.animator.stop();
-							p.axisAnimations.y && p.axisAnimations.y.animator.stop();
-						}
-					})
+					if (topScrollerAnimator) {
+						overlappingAnimators.forEach(p => {
+							if (p !== topScrollerAnimator) {
+								p.axisAnimations.x && p.axisAnimations.x.animator.stop();
+								p.axisAnimations.y && p.axisAnimations.y.animator.stop();
+							}
+						})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
As mentioned in issue #54 - when you have scrollable vertical containers, scrolling by dragging a card horizontally can be busted.

This new option basically disables the automatic scroll overlap detection and puts the onus on the consumer to set up their UI in a way that overlaps are easy to navigate.