### PR TITLE
to get Dropped Element

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -167,7 +167,7 @@ function handleDrop({ element, draggables, layout, getOptions }: ContainerProps)
           removedIndex,
           addedIndex: actualAddIndex,
           payload: draggableInfo.payload,
-          // droppedElement: draggableInfo.element.firstElementChild,
+          draggables: draggables,
         };
         dropHandler(dropHandlerParams, getOptions().onDrop);
       }


### PR DESCRIPTION
        onDrop(dropResult) {
            const { removedIndex, addedIndex, payload, draggables } = dropResult;
            console.log(draggables[addedIndex]) // get Dropped Element
        }