### PR TITLE
Scrolling in touch devices -  bug fixed

### DIFF
--- a/src/mediator.ts
+++ b/src/mediator.ts
@@ -360,7 +360,9 @@ function onMouseDown(event: MouseEvent & TouchEvent) {
           window.document.removeEventListener('mouseup', onMouseUp);
         }
 
-        window.document.addEventListener('mouseup', onMouseUp);
+        releaseEvents.forEach(e => {
+          window.document.addEventListener(e, onMouseUp, { passive: false });
+        });
       }
 
       if (startDrag) {


### PR DESCRIPTION
As mentioned in issues #83 and #69 - touching any smooth-dnd draggable in touch devices disabled the ability to scroll, until user taps outside of draggable. This is a very simple fix to this bug.