### PR TITLE
fix: Executing polyfills code multiple times throws illegal invocation error

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -24,16 +24,16 @@ function applyPolyfills() {
     if (
       constructor &&
       constructor.prototype &&
-      constructor.prototype.firstElementChild == null
+      !constructor.prototype.hasOwnProperty('firstElementChild')
     ) {
       Object.defineProperty(constructor.prototype, "firstElementChild", {
         get: function () {
-          var node,
-            nodes = this.childNodes,
-            i = 0;
-          while ((node = nodes[i++])) {
-            if (node.nodeType === 1) {
-              return node;
+          if(this !== constructor.prototype) {
+            var node, nodes = this.childNodes, i = 0;
+            while ((node = nodes[i++])) {
+              if (node.nodeType === 1) {
+                return node;
+              }
             }
           }
           return null;


### PR DESCRIPTION
I found out that executing polyfill code multiple times will throw "illegal invocation" error. For the first time runnint the code `Z.prototype.firstElementChild == null`, we set a getter for Z.prototype.FirstElementChild through `Object.defineProperty`, which is expected. However, if this polyfill runs again by accident (or just access Z.prototype.firstElementChild), we will get an error. Because inside the Z.prototype.firstElementChild, there is a **this.childNodes** in getter, which will be intercepted by the browser (I don't know why, I guess Chrome has such a restriction in case we access Node.prototype.childNodes directly),  then **Uncaught TypeError: Illegal invocation**  happened. Here's my reproduce url https://jsbin.com/sirihugoya/edit?html,console,output, you can have a check, and you can find an error in devtool console after clicking the "test" button multiple times. @kutlugsahin 