### PR TITLE
fix bug: throw TypeError: Illegal invocation

### DIFF
--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -24,7 +24,11 @@ function applyPolyfills() {
     if (
       constructor &&
       constructor.prototype &&
-      constructor.prototype.firstElementChild == null
+      (
+        // Fix an error when getting Node.prototype.childNodes in the get method of the first polyfill join triggered by calling Node.prototype.firstElementChild when loading smooth-dnd multiple times.
+        (Object.getOwnPropertyNames && !Object.getOwnPropertyNames(constructor.prototype).includes('firstElementChild')) || 
+        constructor.prototype.firstElementChild == null
+      )
     ) {
       Object.defineProperty(constructor.prototype, "firstElementChild", {
         get: function () {

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -26,8 +26,9 @@ function applyPolyfills() {
       constructor.prototype &&
       (
         // Fix an error when getting Node.prototype.childNodes in the get method of the first polyfill join triggered by calling Node.prototype.firstElementChild when loading smooth-dnd multiple times.
-        (Object.getOwnPropertyNames && !Object.getOwnPropertyNames(constructor.prototype).includes('firstElementChild')) || 
-        constructor.prototype.firstElementChild == null
+        Object.getOwnPropertyNames ?
+          !Object.getOwnPropertyNames(constructor.prototype).includes('firstElementChild')): 
+          constructor.prototype.firstElementChild == null
       )
     ) {
       Object.defineProperty(constructor.prototype, "firstElementChild", {


### PR DESCRIPTION
If smooth-dnd is imported in a Module federation(https://webpack.js.org/concepts/module-federation/) module, and the main application also import smooth-dnd, this will cause the polyfill in it to be loaded multiple times.

This will cause the second time it is loaded, the first execution of the get method added by the polyfill will be triggered by the polyfill determining whether Node.prototype.firstElementChild exists, which will call Node.prototype.childNodes, which will trigger the browser to throw an 'TypeError: Illegal invocation' error